### PR TITLE
Use `hatch` for packaging

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2023-present adamghill <adamghill@yahoo.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 # transformd
 
+[![PyPI - Version](https://img.shields.io/pypi/v/transformd.svg)](https://pypi.org/project/transformd)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/transformd.svg)](https://pypi.org/project/transformd)
+
 Transform a `dictionary` to another `dictionary` that keeps the same shape.
+
+-----
+
+**Table of Contents**
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+```console
+pip install transformd
+```
+
+## License
+
+`transformd` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.
+
+## Run tests
+
+`hatch run test`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,155 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "transformd"
-version = "0.1.0"
-description = "Transform dictionaries into whatever your heart desires"
+dynamic = ["version"]
+description = ''
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+keywords = []
 authors = [
-    { name = "Adam Hill" }
+  { name = "Adam Hill" },
 ]
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
 ]
-requires-python = ">= 3.10"
-readme = "README.md"
-
-dependencies = [
-    "mergedeep==1.3.4",
-    "typeguard==4.1.5"
-]
+dependencies = ["mergedeep==1.3.4", "typeguard==4.1.5"]
 
 [project.urls]
-"Homepage" = "https://github.com/adamghill/transformd"
+Documentation = "https://github.com/unknown/transformd#readme"
+Issues = "https://github.com/unknown/transformd/issues"
+Source = "https://github.com/unknown/transformd"
 
-[build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+[tool.hatch.version]
+path = "src/transformd/__about__.py"
+
+[tool.hatch.envs.default]
+python="3.10"
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest"
+]
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+cov-report = [
+  "- coverage combine",
+  "coverage report",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+
+[[tool.hatch.envs.all.matrix]]
+python = ["3.10", "3.11"]
+
+[tool.hatch.envs.lint]
+detached = true
+dependencies = [
+  "black>=23.1.0",
+  "mypy>=1.0.0",
+  "ruff>=0.0.243",
+]
+[tool.hatch.envs.lint.scripts]
+typing = "mypy --install-types --non-interactive {args:src/transformd tests}"
+style = [
+  "ruff {args:.}",
+  "black --check --diff {args:.}",
+]
+fmt = [
+  "black {args:.}",
+  "ruff --fix {args:.}",
+  "style",
+]
+all = [
+  "style",
+  "typing",
+]
+
+[tool.black]
+target-version = ["py37"]
+line-length = 120
+skip-string-normalization = true
+
+[tool.ruff]
+target-version = "py37"
+line-length = 120
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "DTZ",
+  "E",
+  "EM",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "ISC",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
+ignore = [
+  # Allow non-abstract empty methods in abstract base classes
+  "B027",
+  # Allow boolean positional values in function calls, like `dict.get(... True)`
+  "FBT003",
+  # Ignore checks for possible passwords
+  "S105", "S106", "S107",
+  # Ignore complexity
+  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+]
+unfixable = [
+  # Don't touch unused imports
+  "F401",
+]
+
+[tool.ruff.isort]
+known-first-party = ["transformd"]
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.per-file-ignores]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
+
+[tool.coverage.run]
+source_pkgs = ["transformd", "tests"]
+branch = true
+parallel = true
+omit = [
+  "src/transformd/__about__.py",
+]
+
+[tool.coverage.paths]
+transformd = ["src/transformd", "*/transformd/src/transformd"]
+tests = ["tests", "*/transformd/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]

--- a/src/transformd/__about__.py
+++ b/src/transformd/__about__.py
@@ -1,3 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Adam Hill
 #
 # SPDX-License-Identifier: MIT
+__version__ = "0.1.0"

--- a/src/transformd/__init__.py
+++ b/src/transformd/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023-present Adam Hill
+#
+# SPDX-License-Identifier: MIT
+
 from transformd.transformer import DictionaryTransformer
 
 __all__ = [

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from transformd import DictionaryTransformer
+from transformd.transformer import DictionaryTransformer
 
 
 @pytest.fixture


### PR DESCRIPTION
This is a test to see what it's like to use `hatch` for a simple Python package.