### PR TITLE
Handle exclusion spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ Transform a `dictionary` to another `dictionary`, but keep the same shape based 
 
 ## What is a spec?
 
-It is a string (or sequence of strings) that specifies what "parts" of the dictionary should be included in a new `dictionary` that is returned from the `transform` function. A `spec` uses dot-notation to traverse into the `dictionary`. It can also use indexes if the object is a list.
+It is a string (or sequence of strings) that specifies which "parts" of the dictionary should be included or excluded in a new `dictionary` that is returned from the `transform` function.
+
+A `spec` uses dot-notation to specify how to traverse into the `dictionary`. It can also use indexes if the value of the `dictionary` is a list.
+
+Note: `Specs` are applied to the original `dictionary` in the order they are defined -- the `dictionary` gets updated after each spec.
 
 ## Examples
 
 ```python
 from transformd import Transformer
 
+# Initial `dictionary` we'll transform based on a spec below
 data = {
     "library": {
         "name": "Main St Library",
@@ -32,12 +37,14 @@ data = {
     }
 }
 
+# Only return a nested part of `data`
 assert Transformer(data).transform(spec="library.name") == {
     "library": {
         "name": "Main St Library"
     }
 }
 
+# Return multiple parts of `data`
 assert Transformer(data).transform(spec=("library.name", "library.location.state")) == {
     "library": {
         "name": "Main St Library",
@@ -47,6 +54,7 @@ assert Transformer(data).transform(spec=("library.name", "library.location.state
     }
 }
 
+# Return different parts of a nested list in `data`
 assert Transformer(data).transform(spec=("library.books.0.title", "library.books.1")) == {
     "library": {
         "books": [
@@ -60,6 +68,13 @@ assert Transformer(data).transform(spec=("library.books.0.title", "library.books
         ],
     }
 }
+
+# Exclude pieces from `data` by prefixing a spec with a dash
+assert Transformer(data).transform(spec=("-library.books", "-library.location")) == {
+        "library": {
+            "name": "Main St Library"
+        }
+    }
 ```
 
 ## Why?

--- a/src/transformd/__init__.py
+++ b/src/transformd/__init__.py
@@ -1,4 +1,5 @@
-from transformd.transformer import InvalidSpecError, Transformer
+from transformd.exceptions import InvalidSpecError
+from transformd.transformer import Transformer
 
 __all__ = [
     "Transformer",

--- a/src/transformd/exceptions.py
+++ b/src/transformd/exceptions.py
@@ -1,2 +1,8 @@
 class InvalidSpecError(Exception):
-    pass
+    def __init__(self, key: str, data: dict):
+        self.key = key
+        self.data = data
+
+        message = f"'{self.key}' is invalid"
+
+        super().__init__(message)

--- a/src/transformd/exceptions.py
+++ b/src/transformd/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidSpecError(Exception):
+    pass

--- a/src/transformd/strategies/exclusion.py
+++ b/src/transformd/strategies/exclusion.py
@@ -1,0 +1,59 @@
+from transformd.exceptions import InvalidSpecError
+from transformd.utils import is_int
+
+NESTED_PIECES_COUNT = 2
+
+
+def process(data: dict, spec: str, ignore_invalid: bool = False) -> None:
+    """Handle exclusion specs, i.e. specs that specify which parts of the original dictionary to exclude
+    from a new dictionary. This will be any spec that starts with a dash.
+
+    Args:
+        data: The original data. Gets modified in place.
+        spec: Specifies the data to return.
+        ignore_invalid: Whether to ignore an invalid spec or not. Raises `InvalidSpecError`
+            if `False` and the spec is invalid. Defaults to `False`.
+    """
+
+    # Break the spec into a list of pieces based on dot notation
+    pieces = spec.split(".")
+
+    if len(pieces) <= 1:
+        piece = pieces[0]
+
+        if piece not in data and not ignore_invalid:
+            raise InvalidSpecError()
+
+        del data[piece]
+    elif len(pieces) == NESTED_PIECES_COUNT:
+        (first_piece, second_piece) = pieces
+
+        if first_piece not in data:
+            raise InvalidSpecError()
+
+        if data[first_piece] is not None:
+            if second_piece in data[first_piece]:
+                del data[first_piece][second_piece]
+            elif isinstance(data[first_piece], list) and is_int(second_piece):
+                list_idx = int(second_piece)
+
+                data[first_piece].pop(list_idx)
+            elif not ignore_invalid:
+                raise InvalidSpecError()
+    elif len(pieces) > NESTED_PIECES_COUNT:
+        next_piece_idx = spec.index(".") + 1
+        remaining_spec = spec[next_piece_idx:]
+
+        piece = pieces[0]
+        remaining_data = data[piece]
+
+        if isinstance(remaining_data, list):
+            remaining_spec_pieces = remaining_spec.split(".")
+
+            if len(remaining_spec_pieces) > 1 and is_int(remaining_spec_pieces[0]):
+                list_idx = int(remaining_spec_pieces[0])
+
+                remaining_data = remaining_data[list_idx]
+                remaining_spec = ".".join(remaining_spec_pieces[1:])
+
+        process(data=remaining_data, spec=remaining_spec, ignore_invalid=ignore_invalid)

--- a/src/transformd/strategies/exclusion.py
+++ b/src/transformd/strategies/exclusion.py
@@ -22,14 +22,14 @@ def process(data: dict, spec: str, ignore_invalid: bool = False) -> None:
         piece = pieces[0]
 
         if piece not in data and not ignore_invalid:
-            raise InvalidSpecError()
+            raise InvalidSpecError(key=piece, data=data)
 
         del data[piece]
     elif len(pieces) == NESTED_PIECES_COUNT:
         (first_piece, second_piece) = pieces
 
         if first_piece not in data:
-            raise InvalidSpecError()
+            raise InvalidSpecError(key=first_piece, data=data)
 
         if data[first_piece] is not None:
             if second_piece in data[first_piece]:
@@ -39,7 +39,7 @@ def process(data: dict, spec: str, ignore_invalid: bool = False) -> None:
 
                 data[first_piece].pop(list_idx)
             elif not ignore_invalid:
-                raise InvalidSpecError()
+                raise InvalidSpecError(key=second_piece, data=data)
     elif len(pieces) > NESTED_PIECES_COUNT:
         next_piece_idx = spec.index(".") + 1
         remaining_spec = spec[next_piece_idx:]

--- a/src/transformd/strategies/inclusion.py
+++ b/src/transformd/strategies/inclusion.py
@@ -1,0 +1,74 @@
+from transformd.exceptions import InvalidSpecError
+from transformd.utils import is_int
+
+
+def process(data: dict, spec: str, ignore_invalid: bool = False) -> dict:
+    """Handle inclusion specs, i.e. specs that specify which parts of the original dictionary to include
+    in a new dictionary. This will be any spec that does not start with a dash.
+
+    Args:
+        spec: Specifies the data to return.
+        ignore_invalid: Whether to ignore an invalid spec or not. Raises `InvalidSpecError`
+            if `False` and the spec is invalid. Defaults to `False`.
+
+    Returns:
+        A `dictionary` with only the data that was specified in the spec.
+    """
+
+    piece_data = {}
+    new_data = {}
+
+    # Break the spec into a list of pieces based on dot notation
+    pieces = spec.split(".")
+
+    skip_idx = False
+
+    if len(pieces) == 1:
+        piece_data = new_data
+
+    for idx, piece in enumerate(pieces):
+        if skip_idx:
+            skip_idx = False
+            continue
+
+        if piece in data and isinstance(data[piece], list) and len(pieces) >= idx + 2 and is_int(pieces[idx + 1]):
+            # Handle this as referring to a list
+            if piece not in new_data:
+                new_data[piece] = []
+
+            # Handle the nested attribute inside the list
+            if len(pieces) >= idx + 3:
+                # Create one object and use index of 0 here because `mergedeep`
+                # will handle merging the nested lists together later
+                new_data[piece].append({})
+                new_data = new_data[piece][0]
+
+                # Move the pointer to the object in the list
+                list_idx = int(pieces[idx + 1])
+                data = data[piece][list_idx]
+
+                # Skip the next idx in the list because it specifies the index of the nested list
+                # which is already handled above
+                skip_idx = True
+        elif len(pieces) == idx + 1 and is_int(piece):
+            # Handles a list index, e.g. `books.0`
+
+            list_piece = pieces[idx - 1]
+            list_idx = int(piece)
+
+            new_data[list_piece].append(data[list_piece][list_idx])
+        elif piece in data:
+            if idx == len(pieces) - 1:
+                new_data.update({piece: data[piece]})
+            else:
+                new_data.update({piece: {}})
+
+                if piece_data == {}:
+                    piece_data.update(new_data)
+
+                new_data = new_data[piece]
+                data = data[piece]
+        elif ignore_invalid is False:
+            raise InvalidSpecError(f"'{piece}' is invalid")
+
+    return piece_data

--- a/src/transformd/strategies/inclusion.py
+++ b/src/transformd/strategies/inclusion.py
@@ -69,6 +69,6 @@ def process(data: dict, spec: str, ignore_invalid: bool = False) -> dict:
                 new_data = new_data[piece]
                 data = data[piece]
         elif ignore_invalid is False:
-            raise InvalidSpecError(f"'{piece}' is invalid")
+            raise InvalidSpecError(key=piece, data=data)
 
     return piece_data

--- a/src/transformd/transformer.py
+++ b/src/transformd/transformer.py
@@ -8,6 +8,9 @@ class InvalidSpecError(Exception):
     pass
 
 
+NESTED_PIECES_COUNT = 2
+
+
 @typechecked
 class Transformer:
     """Transforms a dictionary based on a `spec`."""
@@ -32,6 +35,137 @@ class Transformer:
 
         return spec
 
+    def _process_exclusion_spec(self, data: dict, spec: str, ignore_invalid: bool = False) -> None:
+        """Handle exclusion specs, i.e. specs that specify which parts of the original dictionary to exclude
+        from a new dictionary. This will be any spec that starts with a dash.
+
+        Args:
+            data: The original data. Gets modified in place.
+            spec: Specifies the data to return.
+            ignore_invalid: Whether to ignore an invalid spec or not. Raises `InvalidSpecError`
+                if `False` and the spec is invalid. Defaults to `False`.
+        """
+
+        # Break the spec into a list of pieces based on dot notation
+        pieces = spec.split(".")
+
+        if len(pieces) <= 1:
+            piece = pieces[0]
+
+            if piece not in data and not ignore_invalid:
+                raise InvalidSpecError()
+
+            del data[piece]
+        elif len(pieces) == NESTED_PIECES_COUNT:
+            (first_piece, second_piece) = pieces
+
+            if first_piece not in data:
+                raise InvalidSpecError()
+
+            if data[first_piece] is not None:
+                if second_piece in data[first_piece]:
+                    del data[first_piece][second_piece]
+                elif isinstance(data[first_piece], list) and is_int(second_piece):
+                    list_idx = int(second_piece)
+
+                    data[first_piece].pop(list_idx)
+                elif not ignore_invalid:
+                    raise InvalidSpecError()
+        elif len(pieces) > NESTED_PIECES_COUNT:
+            next_piece_idx = spec.index(".") + 1
+            remaining_spec = spec[next_piece_idx:]
+
+            piece = pieces[0]
+            remaining_data = data[piece]
+
+            if isinstance(remaining_data, list):
+                remaining_spec_pieces = remaining_spec.split(".")
+
+                if len(remaining_spec_pieces) > 1 and is_int(remaining_spec_pieces[0]):
+                    list_idx = int(remaining_spec_pieces[0])
+
+                    remaining_data = remaining_data[list_idx]
+                    remaining_spec = ".".join(remaining_spec_pieces[1:])
+
+            self._process_exclusion_spec(data=remaining_data, spec=remaining_spec, ignore_invalid=ignore_invalid)
+
+    def _process_inclusion_spec(self, spec: str, ignore_invalid: bool = False) -> dict:
+        """Handle inclusion specs, i.e. specs that specify which parts of the original dictionary to include
+        in a new dictionary. This will be any spec that does not start with a dash.
+
+        Args:
+            spec: Specifies the data to return.
+            ignore_invalid: Whether to ignore an invalid spec or not. Raises `InvalidSpecError`
+                if `False` and the spec is invalid. Defaults to `False`.
+
+        Returns:
+            A `dictionary` with only the data that was specified in the spec.
+        """
+
+        current_data = self.data
+        piece_data = {}
+        new_data = {}
+
+        # Break the spec into a list of pieces based on dot notation
+        pieces = spec.split(".")
+
+        skip_idx = False
+
+        if len(pieces) == 1:
+            piece_data = new_data
+
+        for idx, piece in enumerate(pieces):
+            if skip_idx:
+                skip_idx = False
+                continue
+
+            if (
+                piece in current_data
+                and isinstance(current_data[piece], list)
+                and len(pieces) >= idx + 2
+                and is_int(pieces[idx + 1])
+            ):
+                # Handle this as referring to a list
+                if piece not in new_data:
+                    new_data[piece] = []
+
+                # Handle the nested attribute inside the list
+                if len(pieces) >= idx + 3:
+                    # Create one object and use index of 0 here because `mergedeep`
+                    # will handle merging the nested lists together later
+                    new_data[piece].append({})
+                    new_data = new_data[piece][0]
+
+                    # Move the pointer to the object in the list
+                    list_idx = int(pieces[idx + 1])
+                    current_data = current_data[piece][list_idx]
+
+                    # Skip the next idx in the list because it specifies the index of the nested list
+                    # which is already handled above
+                    skip_idx = True
+            elif len(pieces) == idx + 1 and is_int(piece):
+                # Handles a list index, e.g. `books.0`
+
+                list_piece = pieces[idx - 1]
+                list_idx = int(piece)
+
+                new_data[list_piece].append(current_data[list_piece][list_idx])
+            elif piece in current_data:
+                if idx == len(pieces) - 1:
+                    new_data.update({piece: current_data[piece]})
+                else:
+                    new_data.update({piece: {}})
+
+                    if piece_data == {}:
+                        piece_data.update(new_data)
+
+                    new_data = new_data[piece]
+                    current_data = current_data[piece]
+            elif ignore_invalid is False:
+                raise InvalidSpecError(f"'{piece}' is invalid")
+
+        return piece_data
+
     def transform(self, spec: str | tuple[str, ...] | list[str], ignore_invalid: bool = False) -> dict:
         """Transforms a dictionary based on a `spec` to keep the same "shape" of the original dictionary,
         but only include the pieces of the dictionary that are specified with dot-notation.
@@ -49,69 +183,22 @@ class Transformer:
         specs = self._get_specs(spec)
 
         for spec in specs:
-            current_data = self.data
-            piece_data = {}
-            new_data = {}
+            if spec.startswith("-"):
+                exclusion_spec = spec[1:]
+                excluded_data = transformed_data or self.data
 
-            # Break the spec into a list based on dots
-            pieces = spec.split(".")
+                self._process_exclusion_spec(data=excluded_data, spec=exclusion_spec, ignore_invalid=ignore_invalid)
 
-            skip_idx = False
+                # Overwrite with the excluded data
+                transformed_data = excluded_data
+            else:
+                included_data = self._process_inclusion_spec(spec=spec, ignore_invalid=ignore_invalid)
 
-            if len(pieces) == 1:
-                piece_data = new_data
-
-            for idx, piece in enumerate(pieces):
-                if skip_idx:
-                    skip_idx = False
-                    continue
-
-                if (
-                    piece in current_data
-                    and isinstance(current_data[piece], list)
-                    and len(pieces) >= idx + 2
-                    and is_int(pieces[idx + 1])
-                ):
-                    # Handle this as referring to a list
-                    if piece not in new_data:
-                        new_data[piece] = []
-
-                    # Handle the nested attribute inside the list
-                    if len(pieces) >= idx + 3:
-                        # Create one object and use index of 0 here because `mergedeep`
-                        # will handle merging the nested lists together later
-                        new_data[piece].append({})
-                        new_data = new_data[piece][0]
-
-                        # Move the pointer to the object in the list
-                        list_idx = int(pieces[idx + 1])
-                        current_data = current_data[piece][list_idx]
-
-                        # Skip the next idx in the list because it specifies the index of the nested list
-                        # which is already handled above
-                        skip_idx = True
-                elif len(pieces) == idx + 1 and is_int(piece):
-                    # Handles a list index, e.g. `books.0`
-
-                    list_piece = pieces[idx - 1]
-                    list_idx = int(piece)
-
-                    new_data[list_piece].append(current_data[list_piece][list_idx])
-                elif piece in current_data:
-                    if idx == len(pieces) - 1:
-                        new_data.update({piece: current_data[piece]})
-                    else:
-                        new_data.update({piece: {}})
-
-                        if piece_data == {}:
-                            piece_data.update(new_data)
-
-                        new_data = new_data[piece]
-                        current_data = current_data[piece]
-                elif ignore_invalid is False:
-                    raise InvalidSpecError(f"'{piece}' is invalid")
-
-            # Specify the additive strategy so that nothing gets clobbered while merging
-            merge(transformed_data, piece_data, strategy=Strategy.ADDITIVE)
+                # Specify the additive strategy so that nothing gets clobbered while merging
+                merge(
+                    transformed_data,
+                    included_data,
+                    strategy=Strategy.ADDITIVE,
+                )
 
         return transformed_data

--- a/src/transformd/transformer.py
+++ b/src/transformd/transformer.py
@@ -1,14 +1,7 @@
 from mergedeep import Strategy, merge
 from typeguard import typechecked
 
-from transformd.utils import is_int
-
-
-class InvalidSpecError(Exception):
-    pass
-
-
-NESTED_PIECES_COUNT = 2
+from transformd.strategies import exclusion, inclusion
 
 
 @typechecked
@@ -35,137 +28,6 @@ class Transformer:
 
         return spec
 
-    def _process_exclusion_spec(self, data: dict, spec: str, ignore_invalid: bool = False) -> None:
-        """Handle exclusion specs, i.e. specs that specify which parts of the original dictionary to exclude
-        from a new dictionary. This will be any spec that starts with a dash.
-
-        Args:
-            data: The original data. Gets modified in place.
-            spec: Specifies the data to return.
-            ignore_invalid: Whether to ignore an invalid spec or not. Raises `InvalidSpecError`
-                if `False` and the spec is invalid. Defaults to `False`.
-        """
-
-        # Break the spec into a list of pieces based on dot notation
-        pieces = spec.split(".")
-
-        if len(pieces) <= 1:
-            piece = pieces[0]
-
-            if piece not in data and not ignore_invalid:
-                raise InvalidSpecError()
-
-            del data[piece]
-        elif len(pieces) == NESTED_PIECES_COUNT:
-            (first_piece, second_piece) = pieces
-
-            if first_piece not in data:
-                raise InvalidSpecError()
-
-            if data[first_piece] is not None:
-                if second_piece in data[first_piece]:
-                    del data[first_piece][second_piece]
-                elif isinstance(data[first_piece], list) and is_int(second_piece):
-                    list_idx = int(second_piece)
-
-                    data[first_piece].pop(list_idx)
-                elif not ignore_invalid:
-                    raise InvalidSpecError()
-        elif len(pieces) > NESTED_PIECES_COUNT:
-            next_piece_idx = spec.index(".") + 1
-            remaining_spec = spec[next_piece_idx:]
-
-            piece = pieces[0]
-            remaining_data = data[piece]
-
-            if isinstance(remaining_data, list):
-                remaining_spec_pieces = remaining_spec.split(".")
-
-                if len(remaining_spec_pieces) > 1 and is_int(remaining_spec_pieces[0]):
-                    list_idx = int(remaining_spec_pieces[0])
-
-                    remaining_data = remaining_data[list_idx]
-                    remaining_spec = ".".join(remaining_spec_pieces[1:])
-
-            self._process_exclusion_spec(data=remaining_data, spec=remaining_spec, ignore_invalid=ignore_invalid)
-
-    def _process_inclusion_spec(self, spec: str, ignore_invalid: bool = False) -> dict:
-        """Handle inclusion specs, i.e. specs that specify which parts of the original dictionary to include
-        in a new dictionary. This will be any spec that does not start with a dash.
-
-        Args:
-            spec: Specifies the data to return.
-            ignore_invalid: Whether to ignore an invalid spec or not. Raises `InvalidSpecError`
-                if `False` and the spec is invalid. Defaults to `False`.
-
-        Returns:
-            A `dictionary` with only the data that was specified in the spec.
-        """
-
-        current_data = self.data
-        piece_data = {}
-        new_data = {}
-
-        # Break the spec into a list of pieces based on dot notation
-        pieces = spec.split(".")
-
-        skip_idx = False
-
-        if len(pieces) == 1:
-            piece_data = new_data
-
-        for idx, piece in enumerate(pieces):
-            if skip_idx:
-                skip_idx = False
-                continue
-
-            if (
-                piece in current_data
-                and isinstance(current_data[piece], list)
-                and len(pieces) >= idx + 2
-                and is_int(pieces[idx + 1])
-            ):
-                # Handle this as referring to a list
-                if piece not in new_data:
-                    new_data[piece] = []
-
-                # Handle the nested attribute inside the list
-                if len(pieces) >= idx + 3:
-                    # Create one object and use index of 0 here because `mergedeep`
-                    # will handle merging the nested lists together later
-                    new_data[piece].append({})
-                    new_data = new_data[piece][0]
-
-                    # Move the pointer to the object in the list
-                    list_idx = int(pieces[idx + 1])
-                    current_data = current_data[piece][list_idx]
-
-                    # Skip the next idx in the list because it specifies the index of the nested list
-                    # which is already handled above
-                    skip_idx = True
-            elif len(pieces) == idx + 1 and is_int(piece):
-                # Handles a list index, e.g. `books.0`
-
-                list_piece = pieces[idx - 1]
-                list_idx = int(piece)
-
-                new_data[list_piece].append(current_data[list_piece][list_idx])
-            elif piece in current_data:
-                if idx == len(pieces) - 1:
-                    new_data.update({piece: current_data[piece]})
-                else:
-                    new_data.update({piece: {}})
-
-                    if piece_data == {}:
-                        piece_data.update(new_data)
-
-                    new_data = new_data[piece]
-                    current_data = current_data[piece]
-            elif ignore_invalid is False:
-                raise InvalidSpecError(f"'{piece}' is invalid")
-
-        return piece_data
-
     def transform(self, spec: str | tuple[str, ...] | list[str], ignore_invalid: bool = False) -> dict:
         """Transforms a dictionary based on a `spec` to keep the same "shape" of the original dictionary,
         but only include the pieces of the dictionary that are specified with dot-notation.
@@ -187,12 +49,12 @@ class Transformer:
                 exclusion_spec = spec[1:]
                 excluded_data = transformed_data or self.data
 
-                self._process_exclusion_spec(data=excluded_data, spec=exclusion_spec, ignore_invalid=ignore_invalid)
+                exclusion.process(data=excluded_data, spec=exclusion_spec, ignore_invalid=ignore_invalid)
 
                 # Overwrite with the excluded data
                 transformed_data = excluded_data
             else:
-                included_data = self._process_inclusion_spec(spec=spec, ignore_invalid=ignore_invalid)
+                included_data = inclusion.process(data=self.data, spec=spec, ignore_invalid=ignore_invalid)
 
                 # Specify the additive strategy so that nothing gets clobbered while merging
                 merge(

--- a/tests/transformer/test_core.py
+++ b/tests/transformer/test_core.py
@@ -20,6 +20,17 @@ def test_invalid_spec(transformer):
     assert "'missing' is invalid" in e.exconly()
 
 
+def test_invalid_spec_exception_has_data(transformer):
+    with pytest.raises(InvalidSpecError) as e:
+        transformer.transform(spec="library.missing")
+
+    expected_key = "missing"
+    assert expected_key == e.value.key
+
+    expected_data = transformer.data["library"]
+    assert expected_data == e.value.data
+
+
 def test_invalid_spec_ignore_invalid(transformer):
     expected = {"library": {}}
     actual = transformer.transform(spec="library.missing", ignore_invalid=True)

--- a/tests/transformer/test_exclusion.py
+++ b/tests/transformer/test_exclusion.py
@@ -1,0 +1,88 @@
+# Import any fixtures to be used in test functions
+from tests.transformer.fixtures import *  # noqa: F403
+
+
+def test_whole(transformer):
+    expected = {}
+
+    actual = transformer.transform(spec="-library")
+
+    assert expected == actual
+
+
+def test_nested(transformer):
+    expected = {
+        "library": {
+            "name": "Main St Library",
+            "books": [
+                {
+                    "title": "The Grapes of Wrath",
+                    "author": {"first_name": "John", "last_name": "Steinbeck"},
+                },
+                {
+                    "title": "Slaughterhouse-Five",
+                    "author": {"first_name": "Kurt", "last_name": "Vonnegut"},
+                },
+            ],
+        }
+    }
+
+    actual = transformer.transform(spec="-library.location")
+
+    assert expected == actual
+
+
+def test_multiple(transformer):
+    expected = {"library": {"name": "Main St Library"}}
+
+    spec = (
+        "-library.location",
+        "-library.books",
+    )
+    actual = transformer.transform(spec=spec)
+
+    assert expected == actual
+
+
+def test_list(transformer):
+    expected = {
+        "library": {
+            "books": [
+                {
+                    "title": "Slaughterhouse-Five",
+                    "author": {"first_name": "Kurt", "last_name": "Vonnegut"},
+                },
+            ],
+        }
+    }
+
+    spec = (
+        "-library.location",
+        "-library.name",
+        "-library.books.0",
+    )
+    actual = transformer.transform(spec=spec)
+
+    assert expected == actual
+
+
+def test_list_with_nest(transformer):
+    expected = {
+        "library": {
+            "books": [
+                {
+                    "title": "Slaughterhouse-Five",
+                },
+            ],
+        }
+    }
+
+    spec = (
+        "-library.location",
+        "-library.name",
+        "-library.books.0",
+        "-library.books.0.author",
+    )
+    actual = transformer.transform(spec=spec)
+
+    assert expected == actual

--- a/tests/transformer/test_inclusion.py
+++ b/tests/transformer/test_inclusion.py
@@ -13,7 +13,8 @@ def test_nested(transformer):
         }
     }
 
-    actual = transformer.transform(spec=("library.location",))
+    spec = ("library.location",)
+    actual = transformer.transform(spec=spec)
 
     assert expected == actual
 
@@ -21,7 +22,8 @@ def test_nested(transformer):
 def test_nested_multiple(transformer):
     expected = {"library": {"location": {"street": "123 Main St"}}}
 
-    actual = transformer.transform(spec=("library.location.street",))
+    spec = ("library.location.street",)
+    actual = transformer.transform(spec=spec)
 
     assert expected == actual
 
@@ -36,12 +38,11 @@ def test_multiple_nested(transformer):
         }
     }
 
-    actual = transformer.transform(
-        spec=(
-            "library.name",
-            "library.location.state",
-        )
+    spec = (
+        "library.name",
+        "library.location.state",
     )
+    actual = transformer.transform(spec=spec)
 
     assert actual == expected
 
@@ -57,12 +58,11 @@ def test_multiple_overridden(transformer):
         }
     }
 
-    actual = transformer.transform(
-        spec=(
-            "library.location",
-            "library.location.street",
-        )
+    spec = (
+        "library.location",
+        "library.location.street",
     )
+    actual = transformer.transform(spec=spec)
 
     assert actual == expected
 
@@ -78,12 +78,11 @@ def test_multiple_overridden_2(transformer):
         }
     }
 
-    actual = transformer.transform(
-        spec=(
-            "library.location.street",
-            "library.location",
-        )
+    spec = (
+        "library.location.street",
+        "library.location",
     )
+    actual = transformer.transform(spec=spec)
 
     assert actual == expected
 
@@ -102,12 +101,11 @@ def test_list(transformer):
         }
     }
 
-    actual = transformer.transform(
-        spec=(
-            "library.books.0.author",
-            "library.books.1.author",
-        )
+    spec = (
+        "library.books.0.author",
+        "library.books.1.author",
     )
+    actual = transformer.transform(spec=spec)
 
     assert expected == actual
 
@@ -126,12 +124,11 @@ def test_list_with_nested(transformer):
         }
     }
 
-    actual = transformer.transform(
-        spec=(
-            "library.books.0.author.last_name",
-            "library.books.1.author",
-        )
+    spec = (
+        "library.books.0.author.last_name",
+        "library.books.1.author",
     )
+    actual = transformer.transform(spec=spec)
 
     assert expected == actual
 
@@ -152,7 +149,8 @@ def test_entire_list(transformer):
         }
     }
 
-    actual = transformer.transform(spec=("library.books",))
+    spec = ("library.books",)
+    actual = transformer.transform(spec=spec)
 
     assert expected == actual
 
@@ -172,11 +170,10 @@ def test_list_with_index(transformer):
         }
     }
 
-    actual = transformer.transform(
-        spec=(
-            "library.books.0",
-            "library.books.1.author",
-        )
+    spec = (
+        "library.books.0",
+        "library.books.1.author",
     )
+    actual = transformer.transform(spec=spec)
 
     assert expected == actual

--- a/tests/transformer/test_transformer.py
+++ b/tests/transformer/test_transformer.py
@@ -1,0 +1,24 @@
+# Import any fixtures to be used in test functions
+from tests.transformer.fixtures import *  # noqa: F403
+
+
+def test_both_inclusion_and_exclusion(transformer):
+    expected = {
+        "library": {
+            "books": [
+                {
+                    "title": "The Grapes of Wrath",
+                    "author": {"first_name": "John", "last_name": "Steinbeck"},
+                },
+            ],
+        }
+    }
+
+    spec = (
+        "library.name",
+        "library.books.0",
+        "-library.name",
+    )
+    actual = transformer.transform(spec=spec)
+
+    assert expected == actual


### PR DESCRIPTION
It would be nice to handle exclusion specs. For example:

```python
data = {
    "library": {
        "name": "Main St Library",
        "location": {
            "street": "123 Main St",
            "city": "New York City",
            "state": "NY",
        },
        "books": [
            {
                "title": "The Grapes of Wrath",
                "author": {"first_name": "John", "last_name": "Steinbeck"},
            },
            {
                "title": "Slaughterhouse-Five",
                "author": {"first_name": "Kurt", "last_name": "Vonnegut"},
            },
        ],
    }
}

assert Transformer(data).transform(spec="-library.books") == {
        "library": {
            "name": "Main St Library",
            "location": {
                "street": "123 Main St",
                "city": "New York City",
                "state": "NY",
            }
        }
    }
```